### PR TITLE
Fix three simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 `embed` is a package that contains extra steps for the [`recipes`](http://cran.rstudio.com/package=recipes) package for embedding categorical predictors into one or more numeric columns. All of the preprocessing methods are _supervised_. 
 
-These steps are contained in a separate package because the package dependencies, [`rstanarm`](http://cran.rstudio.com/package= rstanarm) and [`keras`](http://cran.rstudio.com/package= keras),  are fairly heavy. 
+These steps are contained in a separate package because the package dependencies, [`rstanarm`](http://cran.rstudio.com/package=rstanarm) and [`keras`](http://cran.rstudio.com/package=keras),  are fairly heavy. 
 
 The steps included are:
 
@@ -11,7 +11,7 @@ The steps included are:
 Some references for these methods are:
 
 * Francois C and Allaire JJ (2018) [_Deep Learning with R_](https://www.manning.com/books/deep-learning-with-r), Manning
-* Guo, C and Berkhahn F (2106) "[Entity Embeddings of Categorical Variables](https://arxiv.org/abs/1604.06737)"
+* Guo, C and Berkhahn F (2016) "[Entity Embeddings of Categorical Variables](https://arxiv.org/abs/1604.06737)"
 * Zumel N and Mount J (2017) "[`vtreat`: a `data.frame` Processor for Predictive Modeling](https://arxiv.org/abs/1611.09477)"
 
 


### PR DESCRIPTION
Twice an extra space in the package macro, one '2106' citation wants to be '2016'